### PR TITLE
Update test_requires

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,6 @@ all_from 'lib/Module/Install/Repository.pm';
 auto_set_repository;
 
 test_requires 'Test::More';
-test_requires 'Path::Class';
 
 author_tests('xt');
 WriteAll;


### PR DESCRIPTION
The test which required `Path::Class` was removed in commit 04d385067545880d2ea9f25980734a210407a3a5.